### PR TITLE
add gyroactivity to detect phone flipping

### DIFF
--- a/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
+++ b/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
@@ -42,7 +42,7 @@ abstract class GyroActivity : AppCompatActivity(), SensorEventListener {
     }
 
     override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
-        Log.d("GYRO", "accuracy changed")
+        Log.d("GYRO", "accuracy has changed")
 
     }
 

--- a/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
+++ b/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
@@ -42,7 +42,8 @@ abstract class GyroActivity : AppCompatActivity(), SensorEventListener {
     }
 
     override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
-        print("accuracy changed")
+        Log.d("GYRO", "accuracy changed")
+
     }
 
     fun setThreshold(threshold: Int){
@@ -52,7 +53,7 @@ abstract class GyroActivity : AppCompatActivity(), SensorEventListener {
     override fun onSensorChanged(event: SensorEvent?) {
 
         if(event == null)
-            return;
+            return
 
         if (event.sensor.type == Sensor.TYPE_GYROSCOPE) {
             // 3

--- a/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
+++ b/app/src/main/java/com/github/gogetters/letsgo/util/GyroActivity.kt
@@ -1,0 +1,71 @@
+package com.github.gogetters.letsgo.util
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import com.github.gogetters.letsgo.R
+import kotlin.math.abs
+
+//TODO: allow sensorless devices
+abstract class GyroActivity : AppCompatActivity(), SensorEventListener {
+
+
+    private lateinit var sensorManager: SensorManager
+    private var mGyro: Sensor? = null
+    private val gyroReading = FloatArray(3)
+    private var gyroThreshold = 3 //TODO: replace with constant (to be defined elsewhere or here?)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_gyro)
+
+        sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        mGyro = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mGyro?.also { gyro ->
+            sensorManager.registerListener(this, gyro, SensorManager.SENSOR_DELAY_GAME)
+        }
+    }
+
+
+    override fun onPause() {
+        super.onPause()
+        sensorManager.unregisterListener(this)
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        print("accuracy changed")
+    }
+
+    fun setThreshold(threshold: Int){
+        gyroThreshold = threshold
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+
+        if(event == null)
+            return;
+
+        if (event.sensor.type == Sensor.TYPE_GYROSCOPE) {
+            // 3
+
+            if(abs(event.values[1] - gyroReading[1]) > gyroThreshold){
+                Log.d("GYRO", "FLIP DETECTED: difference: " + abs(event.values[1] - gyroReading[1]) + " rotation: " + gyroReading[1])
+                rotationDetected()
+            }
+
+            System.arraycopy(event.values, 0, gyroReading, 0, gyroReading.size)
+        }
+    }
+
+    //child class needs to decide what to do with the detected rotation
+    abstract fun rotationDetected()
+}

--- a/app/src/main/res/layout/activity_gyro.xml
+++ b/app/src/main/res/layout/activity_gyro.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Any activity wanting to detect phone flips needs to extend the GyroActivity. The threshold can be changed using the setter. Tested using the emulator - It always uses the second value of the sensor event, which is adapted on the go once the phone orientation changes.